### PR TITLE
Added ability to supply additional information with a Google Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,47 @@ if (trackingResult.Failed)
 }
 ```
 
+
+If you need to supply additional event metadata supported by the Google Analytics Measurement Protocol, you could use the .AddToCustomPayload call on the tracker object. See example below
+
+```c#
+IEventTracker eventTracker = new EventTracker();
+
+//This is a simple pass-thru of other (not yet supported) Measurement Protocol fields which are not directly related to the Event tracking but might come handy
+// Using custom payload you can send to GA event contextual information such as page or screen where event happened, Custom Dimensions, Custom Metrics
+// GA Measurement Protocol parameters reference: https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters
+//Please see below some commonly used parameters
+
+//Document Location - full uri to the page url
+//https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#dl
+eventTracker.AddToCustomPayload("dl", "https://mytesturl.com/");
+
+//Document title - page title, if you want GA to know page/screen title where event has happened
+//https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#dt
+eventTracker.AddToCustomPayload("dt", "My test title");
+
+//Screen Name - name of the screen where event has happened
+//https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#cd
+eventTracker.AddToCustomPayload("cd", "My screen name");
+
+//Data source. You can use your app name here
+//https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#ds
+eventTracker.AddToCustomPayload("ds", "App Name");
+
+//Custom Dimension. You need to create it first in your GA admin interface
+//https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#cd_
+eventTracker.AddToCustomPayload("cd1", "Custom Dimension 1 value");
+
+//Custom Metric. You need to create it first in your GA admin interface
+//https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#cm_
+eventTracker.AddToCustomPayload("cm1", "100");
+
+//Queue Time. We can modify event time by suppliyng queue time for the hit up to 4 hours in milliseconds
+//https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#qt
+eventTracker.AddToCustomPayload("qt", "560");
+```
+
+
 ## Notes
 The code is almost entirely unit/integration tested so it should be stable and easily updatable. I'm using it on my own site right now so you can find more specific examples at: https://github.com/jakejgordon/NemeStats 
 

--- a/Source/UniversalAnalyticsHttpWrapper/EventTracker.cs
+++ b/Source/UniversalAnalyticsHttpWrapper/EventTracker.cs
@@ -17,6 +17,13 @@ namespace UniversalAnalyticsHttpWrapper
         /// This is the current Google collection URI for version 1 of the measurement protocol
         /// </summary>
         public static readonly Uri GOOGLE_COLLECTION_URI = new Uri("https://www.google-analytics.com/collect");
+
+        /// <summary>
+        /// This is the current Google collection URI used to validate measurement protocol hits. Data sent to this uri is not registered in GA and as a response you can see json object with validation result
+        /// </summary>
+        //public static readonly Uri GOOGLE_COLLECTION_URI_DEBUG = new Uri("https://www.google-analytics.com/debug/collect");
+
+
         /// <summary>
         /// This assembly is built to work with this version of the measurement protocol.
         /// </summary>
@@ -54,7 +61,7 @@ namespace UniversalAnalyticsHttpWrapper
            
             try
             {
-                string postData = this._postDataBuilder.BuildPostDataString(MEASUREMENT_PROTOCOL_VERSION, analyticsEvent);
+                string postData = this._postDataBuilder.BuildPostDataString(MEASUREMENT_PROTOCOL_VERSION, analyticsEvent, _customPayload);
                 this._googleDataSender.SendData(GOOGLE_COLLECTION_URI, postData);
             }
             catch (Exception e)
@@ -76,7 +83,7 @@ namespace UniversalAnalyticsHttpWrapper
 
             try
             {
-                var postData = this._postDataBuilder.BuildPostDataCollection(MEASUREMENT_PROTOCOL_VERSION, analyticsEvent);
+                var postData = this._postDataBuilder.BuildPostDataCollection(MEASUREMENT_PROTOCOL_VERSION, analyticsEvent, _customPayload);
                 await this._googleDataSender.SendDataAsync(GOOGLE_COLLECTION_URI, postData);
             }
             catch (Exception e)
@@ -94,23 +101,24 @@ namespace UniversalAnalyticsHttpWrapper
         /// </summary>
         /// <param name="name">Google Analytics Measurement Protocol short parameter name. for ex: aip, ds, qt, etc</param>
         /// <param name="value">Parameter value</param>
-        public /*bool*/ void AddToCustomPayload(string name, string value)
-        { //completely up to you if this function should return true/false or throw an exception if something goes wrong
+        public void AddToCustomPayload(string name, string value)
+        {
             foreach (string parameter in _postDataBuilder.SupportedParameters)
             {
                 if (parameter == name)
                 {
                     throw new ArgumentException(string.Format("Parameter {0} should not be added as a Custom Payload. Use public object properties instead.", name));
-                    //return false;
                 }
             }
 
             if (_customPayload[name] != null)
+            {
                 _customPayload[name] = value;
+            }
             else
+            {
                 _customPayload.Add(name, value);
-
-            //return true;
+            }
         }
     }
 }

--- a/Source/UniversalAnalyticsHttpWrapper/EventTracker.cs
+++ b/Source/UniversalAnalyticsHttpWrapper/EventTracker.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Specialized;
 using System.Threading.Tasks;
 
 namespace UniversalAnalyticsHttpWrapper
@@ -10,6 +11,7 @@ namespace UniversalAnalyticsHttpWrapper
     {
         private readonly IPostDataBuilder _postDataBuilder;
         private readonly IGoogleDataSender _googleDataSender;
+        private readonly NameValueCollection _customPayload;
 
         /// <summary>
         /// This is the current Google collection URI for version 1 of the measurement protocol
@@ -27,6 +29,7 @@ namespace UniversalAnalyticsHttpWrapper
         {
             this._postDataBuilder = new PostDataBuilder();
             this._googleDataSender = new GoogleDataSender();
+            this._customPayload = new NameValueCollection();
         }
 
         /// <summary>
@@ -82,6 +85,32 @@ namespace UniversalAnalyticsHttpWrapper
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Adds "raw" (custom) payload to the hit data.
+        /// See https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters for parameters list. For example AddToCustomPayload("aip", "1") to enable IP anonymization.
+        /// If parameter was already added, it's value will be replaced with the supplied one
+        /// </summary>
+        /// <param name="name">Google Analytics Measurement Protocol short parameter name. for ex: aip, ds, qt, etc</param>
+        /// <param name="value">Parameter value</param>
+        public /*bool*/ void AddToCustomPayload(string name, string value)
+        { //completely up to you if this function should return true/false or throw an exception if something goes wrong
+            foreach (string parameter in _postDataBuilder.SupportedParameters)
+            {
+                if (parameter == name)
+                {
+                    throw new ArgumentException(string.Format("Parameter {0} should not be added as a Custom Payload. Use public object properties instead.", name));
+                    //return false;
+                }
+            }
+
+            if (_customPayload[name] != null)
+                _customPayload[name] = value;
+            else
+                _customPayload.Add(name, value);
+
+            //return true;
         }
     }
 }

--- a/Source/UniversalAnalyticsHttpWrapper/IEventTracker.cs
+++ b/Source/UniversalAnalyticsHttpWrapper/IEventTracker.cs
@@ -20,5 +20,16 @@ namespace UniversalAnalyticsHttpWrapper
         /// <param name="analyticsEvent"></param>
         /// <returns>The result of the tracking operation</returns>
         Task<TrackingResult> TrackEventAsync(IUniversalAnalyticsEvent analyticsEvent);
+
+
+        /// <summary>
+        /// Adds "raw" (custom) payload to the hit data.
+        /// See https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters for parameters list. For example AddToCustomPayload("aip", "1") to enable IP anonymization.
+        /// Only use this for fields not directly supported by this wrapper. will throw ArgumentException otherwise.
+        /// If parameter was already added, it's value will be replaced with the supplied one
+        /// </summary>
+        /// <param name="name">Google Analytics Measurement Protocol short parameter name. for ex: aip, ds, qt, etc</param>
+        /// <param name="value">Parameter value</param>
+        void AddToCustomPayload(string name, string value);
     }
 }

--- a/Source/UniversalAnalyticsHttpWrapper/IPostDataBuilder.cs
+++ b/Source/UniversalAnalyticsHttpWrapper/IPostDataBuilder.cs
@@ -5,7 +5,7 @@ namespace UniversalAnalyticsHttpWrapper
 {
     internal interface IPostDataBuilder
     {
-        string BuildPostDataString(string measurementProtocolVersion, IUniversalAnalyticsEvent analyticsEvent);
+        string BuildPostDataString(string measurementProtocolVersion, IUniversalAnalyticsEvent analyticsEvent, NameValueCollection customPayload = null);
         IEnumerable<KeyValuePair<string, string>> BuildPostDataCollection(string measurementProtocolVersion, IUniversalAnalyticsEvent analyticsEvent, NameValueCollection customPayload = null);
 
         /// <summary>

--- a/Source/UniversalAnalyticsHttpWrapper/IPostDataBuilder.cs
+++ b/Source/UniversalAnalyticsHttpWrapper/IPostDataBuilder.cs
@@ -1,10 +1,16 @@
 ﻿using System.Collections.Generic;
+using System.Collections.Specialized;
 
 namespace UniversalAnalyticsHttpWrapper
 {
     internal interface IPostDataBuilder
     {
         string BuildPostDataString(string measurementProtocolVersion, IUniversalAnalyticsEvent analyticsEvent);
-        IEnumerable<KeyValuePair<string, string>> BuildPostDataCollection(string measurementProtocolVersion, IUniversalAnalyticsEvent analyticsEvent);
+        IEnumerable<KeyValuePair<string, string>> BuildPostDataCollection(string measurementProtocolVersion, IUniversalAnalyticsEvent analyticsEvent, NameValueCollection customPayload = null);
+
+        /// <summary>
+        /// List of Google Analytics Measurement Protocol Parameters which are currently supported
+        /// </summary>
+        string[] SupportedParameters { get; }
     }
 }

--- a/Source/UniversalAnalyticsHttpWrapper/PostDataBuilder.cs
+++ b/Source/UniversalAnalyticsHttpWrapper/PostDataBuilder.cs
@@ -21,9 +21,9 @@ namespace UniversalAnalyticsHttpWrapper
         internal const string HIT_TYPE_EVENT = "event";
 
 
-        public string BuildPostDataString(string measurementProtocolVersion, IUniversalAnalyticsEvent analyticsEvent)
+        public string BuildPostDataString(string measurementProtocolVersion, IUniversalAnalyticsEvent analyticsEvent, NameValueCollection customPayload = null)
         {
-            var postData = BuildPostData(measurementProtocolVersion, analyticsEvent);
+            var postData = BuildPostData(measurementProtocolVersion, analyticsEvent, customPayload);
             return postData.ToString();
         }
 
@@ -37,9 +37,7 @@ namespace UniversalAnalyticsHttpWrapper
 
             var collection = postData.AllKeys.SelectMany(
                 postData.GetValues,
-                (key, value) => new KeyValuePair<string, string>(key, value));
-
-            
+                (key, value) => new KeyValuePair<string, string>(key, value));            
 
             return collection;
         }

--- a/Source/UniversalAnalyticsHttpWrapper/PostDataBuilder.cs
+++ b/Source/UniversalAnalyticsHttpWrapper/PostDataBuilder.cs
@@ -20,6 +20,7 @@ namespace UniversalAnalyticsHttpWrapper
 
         internal const string HIT_TYPE_EVENT = "event";
 
+
         public string BuildPostDataString(string measurementProtocolVersion, IUniversalAnalyticsEvent analyticsEvent)
         {
             var postData = BuildPostData(measurementProtocolVersion, analyticsEvent);
@@ -27,17 +28,23 @@ namespace UniversalAnalyticsHttpWrapper
         }
 
         public IEnumerable<KeyValuePair<string, string>> BuildPostDataCollection(
-            string measurementProtocolVersion, IUniversalAnalyticsEvent analyticsEvent)
+            string measurementProtocolVersion, 
+            IUniversalAnalyticsEvent analyticsEvent,
+            NameValueCollection customPayload = null
+            )
         {
-            var postData = BuildPostData(measurementProtocolVersion, analyticsEvent);
+            var postData = BuildPostData(measurementProtocolVersion, analyticsEvent, customPayload);
+
             var collection = postData.AllKeys.SelectMany(
                 postData.GetValues,
                 (key, value) => new KeyValuePair<string, string>(key, value));
 
+            
+
             return collection;
         }
 
-        internal NameValueCollection BuildPostData(string measurementProtocolVersion, IUniversalAnalyticsEvent analyticsEvent)
+        internal NameValueCollection BuildPostData(string measurementProtocolVersion, IUniversalAnalyticsEvent analyticsEvent, NameValueCollection customPayload = null)
         {
             NameValueCollection nameValueCollection = HttpUtility.ParseQueryString(string.Empty);
             nameValueCollection[PARAMETER_KEY_VERSION] = measurementProtocolVersion;
@@ -72,8 +79,21 @@ namespace UniversalAnalyticsHttpWrapper
                 nameValueCollection[PARAMETER_KEY_NON_INTERACTION_HIT] = "1";
             }
 
+            //adding custom/externally specified parameters
+            if (customPayload != null)
+            {
+                foreach (string parameter in customPayload)
+                {
+                    if (nameValueCollection[parameter] == null) //do not override supported parameters with user ones
+                    {
+                        nameValueCollection[parameter] = customPayload[parameter];
+                    }
+                }
+            }
+
             return nameValueCollection;
         }
+
 
         /// <summary>
         /// Represents the different Measurement Protocol hit types supported by this package.
@@ -82,5 +102,26 @@ namespace UniversalAnalyticsHttpWrapper
         {
             @event
         }
+
+
+        //lazy initialization of supported GA MP parameters list
+        private string[] _supportedParameters = null;
+        public string[] SupportedParameters
+        {
+            get
+            {
+                if (_supportedParameters == null)    //no need to sync
+                {
+                    _supportedParameters = new string[] {
+                        PARAMETER_KEY_VERSION, PARAMETER_KEY_TRACKING_ID, PARAMETER_KEY_ANONYMOUS_CLIENT_ID, PARAMETER_KEY_USER_ID, PARAMETER_KEY_HIT_TYPE,
+                        PARAMETER_KEY_EVENT_CATEGORY, PARAMETER_KEY_EVENT_ACTION, PARAMETER_KEY_EVENT_LABEL, PARAMETER_KEY_EVENT_VALUE, PARAMETER_KEY_NON_INTERACTION_HIT
+                    };
+                }
+
+                return _supportedParameters;
+            }
+        }
+
+
     }
 }

--- a/Source/UniversalAnalyticsHttpWrapper/UniversalAnalyticsHttpWrapper.csproj
+++ b/Source/UniversalAnalyticsHttpWrapper/UniversalAnalyticsHttpWrapper.csproj
@@ -12,6 +12,8 @@
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Source/UniversalAnalyticsHttpWrapper/UniversalAnalyticsHttpWrapper.sln
+++ b/Source/UniversalAnalyticsHttpWrapper/UniversalAnalyticsHttpWrapper.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.489
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UniversalAnalyticsHttpWrapper", "UniversalAnalyticsHttpWrapper.csproj", "{6F33021F-2FF2-4349-AE7C-ECB57DCBBF4F}"
 EndProject
@@ -24,5 +24,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {99963E2A-48EB-4C0C-9B2B-FFE1EC5DE4D3}
 	EndGlobalSection
 EndGlobal

--- a/Tests/UniversalAnalyticsHttpWrapper.Tests/EventTrackerTests.cs
+++ b/Tests/UniversalAnalyticsHttpWrapper.Tests/EventTrackerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Threading.Tasks;
 using System.Web;
 using NUnit.Framework;
@@ -32,7 +33,8 @@ namespace UniversalAnalyticsHttpWrapper.Tests
             
             _postDataBuilderMock.Expect(mock => mock.BuildPostDataString(
                     Arg<string>.Is.Anything,
-                    Arg<UniversalAnalyticsEvent>.Is.Anything))
+                    Arg<UniversalAnalyticsEvent>.Is.Anything,
+                    Arg<NameValueCollection>.Is.Anything))
                 .Return(expectedPostData);
 
             _eventTracker.TrackEvent(_analyticsEvent);
@@ -48,7 +50,8 @@ namespace UniversalAnalyticsHttpWrapper.Tests
 
             _postDataBuilderMock.Expect(mock => mock.BuildPostDataCollection(
                     Arg<string>.Is.Anything,
-                    Arg<UniversalAnalyticsEvent>.Is.Anything))
+                    Arg<UniversalAnalyticsEvent>.Is.Anything,
+                    Arg<NameValueCollection>.Is.Anything))
                 .Return(expectedPostData);
 
             _googleDataSenderMock.Expect(mock => mock.SendDataAsync(
@@ -69,7 +72,9 @@ namespace UniversalAnalyticsHttpWrapper.Tests
 
             _postDataBuilderMock.Expect(mock => mock.BuildPostDataCollection(
                     Arg<string>.Is.Anything,
-                    Arg<UniversalAnalyticsEvent>.Is.Anything))
+                    Arg<UniversalAnalyticsEvent>.Is.Anything,
+                    Arg<NameValueCollection>.Is.Anything
+                    ))
                 .Return(new List<KeyValuePair<string, string>>());
 
             _googleDataSenderMock.Expect(mock => mock.SendData(Arg<Uri>.Is.Anything,
@@ -88,7 +93,8 @@ namespace UniversalAnalyticsHttpWrapper.Tests
 
             _postDataBuilderMock.Expect(mock => mock.BuildPostDataCollection(
                     Arg<string>.Is.Anything,
-                    Arg<UniversalAnalyticsEvent>.Is.Anything))
+                    Arg<UniversalAnalyticsEvent>.Is.Anything,
+                    Arg<NameValueCollection>.Is.Anything))
                 .Return(new List<KeyValuePair<string, string>>());
 
             _googleDataSenderMock.Expect(mock => mock.SendDataAsync(Arg<Uri>.Is.Anything,

--- a/Tests/UniversalAnalyticsHttpWrapper.Tests/IntegrationTests.cs
+++ b/Tests/UniversalAnalyticsHttpWrapper.Tests/IntegrationTests.cs
@@ -204,5 +204,73 @@ namespace UniversalAnalyticsHttpWrapper.Tests
             Assert.IsFalse(result.Failed);
         }
 
+        //added by Dmitrry Klymenko, 15 Mar 2019 
+        [Test]
+        public void SampleCodeForGitHubReadMeAddingcustomPayload()
+        {
+            IEventTracker eventTracker = new EventTracker();
+
+            //This is a simple pass-thru of other (not yet supported) Measurement Protocol fields which are not directly related to the Event tracking but might come handy
+            // Using custom payload you can send to GA event contextual information such as page or screen where event happened, Custom Dimensions, Custom Metrics
+            // GA Measurement Protocol parameters reference: https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters
+            //Please see below some commonly used parameters
+
+            //Document Location - full uri to the page url
+            //https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#dl
+            eventTracker.AddToCustomPayload("dl", "https://mytesturl.com/");
+
+            //Document title - page title, if you want GA to know page/screen title where event has happened
+            //https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#dt
+            eventTracker.AddToCustomPayload("dt", "My test title");
+
+            //Screen Name - name of the screen where event has happened
+            //https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#cd
+            eventTracker.AddToCustomPayload("cd", "My screen name");
+
+            //Data source. You can use your app name here
+            //https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#ds
+            eventTracker.AddToCustomPayload("ds", "App Name");
+
+            //Custom Dimension. You need to create it first in your GA admin interface
+            //https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#cd_
+            eventTracker.AddToCustomPayload("cd1", "Custom Dimension 1 value");
+
+            //Custom Metric. You need to create it first in your GA admin interface
+            //https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#cm_
+            eventTracker.AddToCustomPayload("cm1", "100");
+
+            //Queue Time. We can modify event time by suppliyng queue time for the hit up to 4 hours in milliseconds
+            //https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#qt
+            eventTracker.AddToCustomPayload("qt", "560");
+
+
+            IUniversalAnalyticsEventFactory eventFactory = new UniversalAnalyticsEventFactory();
+
+            var analyticsEvent = eventFactory.MakeUniversalAnalyticsEvent(
+                // Required if no user id. 
+                // See https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#cid for details.
+                "35009a79-1a05-49d7-b876-2b884d0f825b",
+                // Required. The event category for the event. 
+                // See https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#ec for details.
+                "test category",
+                // Required. The event action for the event. 
+                //See https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#ea for details.
+                "test action",
+                // Optional. The event label for the event.
+                // See https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#el for details.
+                "test label",
+                // Optional. The event value for the event.
+                // See https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#ev for details.
+                "10",
+                // Required if no client id. 
+                // See https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#uid for details.
+                "user-id"
+            );
+
+            var result = eventTracker.TrackEvent(analyticsEvent);
+
+            Assert.IsFalse(result.Failed);
+        }
+
     }
 }

--- a/Tests/UniversalAnalyticsHttpWrapper.Tests/PostDataBuilderTests.cs
+++ b/Tests/UniversalAnalyticsHttpWrapper.Tests/PostDataBuilderTests.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using Rhino.Mocks;
+using System;
 using System.Collections.Specialized;
 using System.Linq;
 using System.Web;
@@ -144,15 +145,26 @@ namespace UniversalAnalyticsHttpWrapper.Tests
             Assert.Null(nameValueCollection[PostDataBuilder.PARAMETER_KEY_EVENT_VALUE]);
         }
 
-        private void ValidateKeyValuePairIsSetOnPostData(string key, string expectedValue)
+
+        //added by Dmitry Klymenko, 15 Mar 2019
+        [Test]
+        public void ItPutsAdditionalPayload()
         {
-            string postDataString = _postDataBuilder.BuildPostDataString(EventTracker.MEASUREMENT_PROTOCOL_VERSION, _analyticsEvent);
+            NameValueCollection nvc = new NameValueCollection(1);
+            nvc.Add("qt", "560");
+
+            ValidateKeyValuePairIsSetOnPostData("qt", "560", nvc);
+        }
+
+        private void ValidateKeyValuePairIsSetOnPostData(string key, string expectedValue, NameValueCollection customPayload = null)
+        {
+            string postDataString = _postDataBuilder.BuildPostDataString(EventTracker.MEASUREMENT_PROTOCOL_VERSION, _analyticsEvent, customPayload);
 
             NameValueCollection nameValueCollection = HttpUtility.ParseQueryString(postDataString);
             string actualValue = nameValueCollection[key];
             Assert.AreEqual(expectedValue, actualValue);
 
-            var postDataCollection = _postDataBuilder.BuildPostDataCollection(EventTracker.MEASUREMENT_PROTOCOL_VERSION, _analyticsEvent);
+            var postDataCollection = _postDataBuilder.BuildPostDataCollection(EventTracker.MEASUREMENT_PROTOCOL_VERSION, _analyticsEvent, customPayload);
             string actualCollectionValue = postDataCollection.Single(s => s.Key == key).Value;
             Assert.AreEqual(expectedValue, actualCollectionValue);
         }

--- a/Tests/UniversalAnalyticsHttpWrapper.Tests/UniversalAnalyticsHttpWrapper.Tests.csproj
+++ b/Tests/UniversalAnalyticsHttpWrapper.Tests/UniversalAnalyticsHttpWrapper.Tests.csproj
@@ -12,6 +12,8 @@
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -33,7 +35,6 @@
   <ItemGroup>
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\..\Source\UniversalAnalyticsHttpWrapper\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Rhino.Mocks, Version=3.6.0.0, Culture=neutral, PublicKeyToken=0b3305902db7183f, processorArchitecture=MSIL">
       <HintPath>..\..\Source\UniversalAnalyticsHttpWrapper\packages\RhinoMocks.3.6.1\lib\net\Rhino.Mocks.dll</HintPath>

--- a/Tests/UniversalAnalyticsHttpWrapper.Tests/packages.config
+++ b/Tests/UniversalAnalyticsHttpWrapper.Tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="2.6.3" targetFramework="net46" />
+  <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net451" />
   <package id="RhinoMocks" version="3.6.1" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
Hi,

First of all, thank you very much for this simple and beautifully working Google Analytics Events wrapper. What I was missing is an ability to supply additional (customer) payload to the Google Analytics Hit. In my case, I was tracking events to the Google Analytics View which does filter inbound traffic using hostnames matching specific format and since I wasn't able to supply Document Location or Page Path together with the hit things were off in my GA. By having this very simple and optional pass-thru for Google Analytics Measurement Protocol parameters/fields from caller code to the internal hit payload builder people will be able to supply additional pieces of data should they need.

Alternatively, I believe it would be beneficial to add support for screenname field, document path, document title and location fields.

Thank you very much for considering my PR.
