### PR TITLE
Added ability to validate hit using Measurement Protocol validate endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,18 @@ eventTracker.AddToCustomPayload("qt", "560");
 ```
 
 
+Validating hit. Since Google Analytics is not letting you know if the data you are suppliyng are valid from GA perspective (always returns 200 in production environment)
+developers are encouraged to validate some of the hits which are being sent vide a specifically designed debug endpoint /debug/collect. Some of the parameters value might be off, etc.
+Using the .ValidateHit method you can check if hit looks valid. See example below
+
+```c#
+IEventTracker eventTracker = new EventTracker();
+TrackingResult res = realEventTracker.ValidateHit(analyticsEvent);
+if(!res.ValidationStatus)	//validation has failed
+	DumpToDiskRequestAndAnalyseLater(analyticsEvent, res.ValidationResult);	//res.ValudationResult holds detailed information returned by GA on what is wrong with the hit
+
+```
+
 ## Notes
 The code is almost entirely unit/integration tested so it should be stable and easily updatable. I'm using it on my own site right now so you can find more specific examples at: https://github.com/jakejgordon/NemeStats 
 

--- a/Source/UniversalAnalyticsHttpWrapper/EventTracker.cs
+++ b/Source/UniversalAnalyticsHttpWrapper/EventTracker.cs
@@ -21,7 +21,7 @@ namespace UniversalAnalyticsHttpWrapper
         /// <summary>
         /// This is the current Google collection URI used to validate measurement protocol hits. Data sent to this uri is not registered in GA and as a response you can see json object with validation result
         /// </summary>
-        //public static readonly Uri GOOGLE_COLLECTION_URI_DEBUG = new Uri("https://www.google-analytics.com/debug/collect");
+        public static readonly Uri GOOGLE_COLLECTION_URI_DEBUG = new Uri("https://www.google-analytics.com/debug/collect");
 
 
         /// <summary>
@@ -120,5 +120,30 @@ namespace UniversalAnalyticsHttpWrapper
                 _customPayload.Add(name, value);
             }
         }
+
+        /// <summary>
+        /// Validates current event (and existing payload data) and puts the result in a container object
+        /// </summary>
+        /// <param name="analyticsEvent">Events to track</param>
+        /// <returns>The result of the hit validation operation</returns>
+        public TrackingResult ValidateHit(IUniversalAnalyticsEvent analyticsEvent)
+        {
+            var result = new TrackingResult();
+
+            try
+            {
+                string postData = this._postDataBuilder.BuildPostDataString(MEASUREMENT_PROTOCOL_VERSION, analyticsEvent, _customPayload);
+                result.ValidationResult = _googleDataSender.SendData(GOOGLE_COLLECTION_URI_DEBUG, postData, /*bReadResponse*/ true);
+            }
+            catch (Exception e)
+            {
+                result.Exception = e;
+            }
+
+            return result;
+        }
+
+
+
     }
 }

--- a/Source/UniversalAnalyticsHttpWrapper/IEventTracker.cs
+++ b/Source/UniversalAnalyticsHttpWrapper/IEventTracker.cs
@@ -31,5 +31,14 @@ namespace UniversalAnalyticsHttpWrapper
         /// <param name="name">Google Analytics Measurement Protocol short parameter name. for ex: aip, ds, qt, etc</param>
         /// <param name="value">Parameter value</param>
         void AddToCustomPayload(string name, string value);
+
+        /// <summary>
+        /// Validates current event (and existing payload data) and puts the result in a container object
+        /// https://developers.google.com/analytics/devguides/collection/protocol/v1/validating-hits
+        /// </summary>
+        /// <param name="analyticsEvent">Events to track</param>
+        /// <returns>The result of the hit validation operation</returns>
+        TrackingResult ValidateHit(IUniversalAnalyticsEvent analyticsEvent);
+
     }
 }

--- a/Source/UniversalAnalyticsHttpWrapper/IGoogleDataSender.cs
+++ b/Source/UniversalAnalyticsHttpWrapper/IGoogleDataSender.cs
@@ -6,7 +6,15 @@ namespace UniversalAnalyticsHttpWrapper
 {
     internal interface IGoogleDataSender
     {
-        void SendData(Uri googleCollectionUri, string postData);
+        /// <summary>
+        /// Sends postData as payload to the googleCollectionUri and returns response as text if readResponse is true
+        /// </summary>
+        /// <param name="googleCollectionUri">URI to send data to</param>
+        /// <param name="postData">Data to be sent as POST payload. Should be correct and valid Google Analytics Measurement Protocol parameters collection</param>
+        /// <param name="readResponse">Read response or not. By default it is false. Response is ONLY required for hit validation</param>
+        /// <returns></returns>
+        string SendData(Uri googleCollectionUri, string postData, bool readResponse = false);
+
         Task SendDataAsync(Uri googleCollectionUri, IEnumerable<KeyValuePair<string, string>> postData);
     }
 }

--- a/Source/UniversalAnalyticsHttpWrapper/TrackingResult.cs
+++ b/Source/UniversalAnalyticsHttpWrapper/TrackingResult.cs
@@ -13,7 +13,7 @@ namespace UniversalAnalyticsHttpWrapper
         /// <param name="exception"></param>
         public TrackingResult(Exception exception = null)
         {
-            this.Exception = exception;
+            Exception = exception;
         }
 
         /// <summary>
@@ -24,5 +24,29 @@ namespace UniversalAnalyticsHttpWrapper
         /// An exception caught during the tracking process. Not thrown for stability.
         /// </summary>
         public Exception Exception { get; internal set; }
+
+
+        /// <summary>
+        /// Complete response of the Google Analytics Measurement Protocol hit validation debug endpoint
+        /// https://developers.google.com/analytics/devguides/collection/protocol/v1/validating-hits
+        /// </summary>
+        public string ValidationResult { get; set; }
+
+        /// <summary>
+        /// If true - hit is valid and might be accepted by Google Analytics
+        ///  Returns value of hitParsingResult[0].valid
+        /// https://developers.google.com/analytics/devguides/collection/protocol/v1/validating-hits
+        /// </summary>
+        public bool ValidationStatus
+        {
+            get
+            {
+                var ret = ValidationResult.Contains("\"valid\": true");
+
+                return ret;
+            }
+
+        }
+
     }
 }


### PR DESCRIPTION
Please consider this added to the master codebase. In some situations, an ability to validate hit to ensure it will be accepted by GA is quite important.

Hits sent to validation endpoint are not tracked and the response contains json with "what is wrong with the request".